### PR TITLE
Fix remote branch check and pass PR arguments correctly

### DIFF
--- a/aipr
+++ b/aipr
@@ -266,6 +266,7 @@ EOF
 
 create_pr() {
     DIFF="$1"
+    shift
     echo -e "${YELLOW}There is no ongoing PR for branch $BASE_REMOTE/$BASE_BRANCH<-$HEAD_REMOTE/$HEAD_BRANCH; will create one ${NC}"
 
     TEMP_FILE=$(mktemp)
@@ -297,6 +298,7 @@ EOF
 
 update_pr() {
     DIFF=$1
+    shift
     echo -e "${YELLOW}There is an ongoing PR for branch $BASE_REMOTE/$BASE_BRANCH<-$HEAD_REMOTE/$HEAD_BRANCH; will update it ${NC}"
 
     SYSTEM=$(cat "$PROMPT_BODY")
@@ -466,7 +468,7 @@ if [ -z "$TEMPLATE" ]; then
 fi
 
 if [ -z "$ONGOING" ]; then
-    create_pr "$DIFF"
+    create_pr "$DIFF" "$@"
 else
-    update_pr "$DIFF"
+    update_pr "$DIFF" "$@"
 fi

--- a/aipr
+++ b/aipr
@@ -103,9 +103,9 @@ check_unpush() {
     if ! git ls-remote --exit-code "$remote" &>/dev/null; then
         return 1
     fi
-
-    local remote_commit=$(git rev-parse "$remote/$branch" 2>/dev/null)
-    [ -z "$remote_commit" ] && return 0
+    if ! git rev-parse --verify "$remote/$branch" >/dev/null 2>&1; then
+        return 1  # Remote branch doesn't exist yet, so nothing to push
+    fi
 
     local unpush=$(git log "$remote/$branch"..HEAD --oneline)
     if [ -n "$unpush" ]; then


### PR DESCRIPTION
# Pull Request: Improved PR Handling and Remote Branch Checks

This PR improves the reliability of the PR creation/update process and fixes some edge cases in remote branch detection. The changes make the script more robust when dealing with non-existent remote branches and properly pass arguments through the PR creation flow.

## Changes Made:

* **Fixed remote branch existence check** in `check_unpush()`:
  - Replaced the silent rev-parse with explicit verification
  - Changed logic to return false when remote branch doesn't exist (rather than true)
  
* **Added proper argument passing** in PR creation/update functions:
  - Added `shift` to properly handle the DIFF argument
  - Pass through remaining arguments (`"$@"`) when calling create_pr/update_pr

* **Fixed argument handling** in main script flow:
  - Now properly passes all arguments to create_pr/update_pr functions

These changes resolve edge cases where:
- The script might incorrectly report unpushed commits when the remote branch doesn't exist
- Arguments could get lost in the PR creation flow
- The remote branch check wasn't as robust as it could be

The improvements make the script more reliable when:
- Working with brand new branches that haven't been pushed yet
- Handling complex argument cases
- Determining actual unpushed commits vs non-existent branches
