### PR TITLE
Update default prompt paths to use aipr instead of llm-pr

### DIFF
--- a/aipr
+++ b/aipr
@@ -336,11 +336,11 @@ EOF
 
 DEFAULT_PROMPT_TITLE=~/.config/prompts/pr-title-prompt.txt
 if [ ! -f "$DEFAULT_PROMPT_TITLE" ]; then
-    DEFAULT_PROMPT_TITLE=$(brew --prefix)/share/llm-pr/prompts/pr-title-prompt.txt
+    DEFAULT_PROMPT_TITLE=$(brew --prefix)/share/aipr/prompts/pr-title-prompt.txt
 fi
 DEFAULT_PROMPT_BODY=~/.config/prompts/pr-body-prompt.txt
 if [ ! -f "$DEFAULT_PROMPT_BODY" ]; then
-    DEFAULT_PROMPT_BODY=$(brew --prefix)/share/llm-pr/prompts/pr-body-prompt.txt
+    DEFAULT_PROMPT_BODY=$(brew --prefix)/share/aipr/prompts/pr-body-prompt.txt
 fi
 
 BASE_REMOTE=origin


### PR DESCRIPTION
# Fix Default Prompt Paths in aipr Script

This PR updates the default prompt file paths in the `aipr` script to correctly reference the `aipr` directory instead of the outdated `llm-pr` directory name.

## Changes Made
- Updated `DEFAULT_PROMPT_TITLE` path from `llm-pr` to `aipr`
- Updated `DEFAULT_PROMPT_BODY` path from `llm-pr` to `aipr`

## Why This Change is Needed
The script was still referencing the old project name (`llm-pr`) in the default prompt file paths, which could cause issues when looking for these files in the correct location after the project was renamed to `aipr`. This ensures the script can find the prompt files in their new location.

This is a simple but important fix to maintain consistency with the project's current name and ensure proper functionality when using default prompt files.
