### PR TITLE
Improve PR creation by deriving the head branch owner from its remote configuration, ensuring accurate PR targeting.

### DIFF
--- a/aipr
+++ b/aipr
@@ -473,7 +473,15 @@ else
 fi
 
 BASE_OWNER=$(echo "$BASE_VIEW" | jq -r '.owner.login')
+if [ -z "$BASE_OWNER" ] || [ "$BASE_OWNER" = "null" ]; then
+    echo "Error: Could not determine owner from repo info for $BASE_URL" >&2
+    exit 1
+fi
 BASE_NAME=$(echo "$BASE_VIEW" | jq -r '.name')
+if [ -z "$BASE_NAME" ] || [ "$BASE_NAME" = "null" ]; then
+    echo "Error: Could not determine repo name from repo info for $BASE_URL" >&2
+    exit 1
+fi
 
 BASE_REPO="$BASE_OWNER/$BASE_NAME"
 

--- a/aipr
+++ b/aipr
@@ -463,7 +463,8 @@ if ! check_unpush "$HEAD_BRANCH" "$HEAD_REMOTE"; then
 fi
 
 if [ "$HEAD_REMOTE" = "$BASE_REMOTE" ]; then
-    BASE_VIEW=$HEAD_VIEW
+    BASE_VIEW="$HEAD_VIEW"
+    BASE_URL="$HEAD_URL"
 else
     BASE_URL=$(remote_2_url "$BASE_REMOTE")
     if ! BASE_VIEW=$(gh repo view --json defaultBranchRef,name,owner "$BASE_URL"); then

--- a/aipr
+++ b/aipr
@@ -458,11 +458,6 @@ if [ -z "$HEAD_OWNER" ] || [ "$HEAD_OWNER" = "null" ]; then
     exit 1
 fi
 
-if [ -z "$HEAD_OWNER" ]; then
-    echo "The owner of $HEAD_URL is not found" >&2
-    exit 1
-fi
-
 if ! check_unpush "$HEAD_BRANCH" "$HEAD_REMOTE"; then
     prompt_push "$HEAD_BRANCH" "$HEAD_REMOTE"
 fi

--- a/aipr
+++ b/aipr
@@ -272,7 +272,7 @@ EOF
 create_pr() {
     DIFF="$1"
     shift
-    echo -e "${YELLOW}Creating PR ${BLUE}${GH_USER}:${HEAD_BRANCH}${YELLOW} -> ${BLUE}${BASE_OWNER}:${BASE_BRANCH}${YELLOW}${NC}..."
+    echo -e "${YELLOW}Creating PR ${BLUE}${HEAD_OWNER}:${HEAD_BRANCH}${YELLOW} -> ${BLUE}${BASE_OWNER}:${BASE_BRANCH}${YELLOW}${NC}..."
 
     TEMP_FILE=$(mktemp)
     generate_title "$DIFF" "$TEMP_FILE"
@@ -295,7 +295,7 @@ EOF
 
     read -p "Create PR with these details? [y/N] " confirm
     if [[ $confirm =~ ^[Yy]$ ]]; then
-        gh pr create -R "$BASE_REPO" -H "${GH_USER}:${HEAD_BRANCH}" -B "${BASE_BRANCH}" -t "$TITLE" -F "$TEMP_FILE" "$@"
+        gh pr create -R "$BASE_REPO" -H "${HEAD_OWNER}:${HEAD_BRANCH}" -B "${BASE_BRANCH}" -t "$TITLE" -F "$TEMP_FILE" "$@"
     else
         echo "PR creation cancelled"
     fi
@@ -305,7 +305,7 @@ EOF
 update_pr() {
     DIFF=$1
     shift
-    echo -e "${YELLOW}Updating PR ${BLUE}${GH_USER}:${HEAD_BRANCH}${YELLOW} -> ${BLUE}${BASE_OWNER}:${BASE_BRANCH}${YELLOW}${NC}..."
+    echo -e "${YELLOW}Updating PR ${BLUE}${HEAD_OWNER}:${HEAD_BRANCH}${YELLOW} -> ${BLUE}${BASE_OWNER}:${BASE_BRANCH}${YELLOW}${NC}..."
 
     SYSTEM=$(cat "$PROMPT_BODY")
 
@@ -446,10 +446,12 @@ git fetch "$BASE_REMOTE"
 kill_spin
 
 HEAD_REMOTE=$(get_branch_remote "$HEAD_BRANCH")
-GH_USER=$(gh config get -h github.com user)
+HEAD_URL=$(remote_2_url "$HEAD_REMOTE")
+HEAD_VIEW=$(gh repo view --json defaultBranchRef,name,owner "$HEAD_URL")
+HEAD_OWNER=$(echo "$HEAD_VIEW" | jq -r '.owner.login')
 
-if [ -z "$GH_USER" ]; then
-    echo "gh is unauthenticated" >&2
+if [ -z "$HEAD_OWNER" ]; then
+    echo "The owner of $HEAD_URL is not found" >&2
     exit 1
 fi
 
@@ -457,8 +459,12 @@ if ! check_unpush "$HEAD_BRANCH" "$HEAD_REMOTE"; then
     prompt_push "$HEAD_BRANCH" "$HEAD_REMOTE"
 fi
 
-BASE_URL=$(remote_2_url "$BASE_REMOTE")
-BASE_VIEW=$(gh repo view --json defaultBranchRef,name,owner "$BASE_URL")
+if [ "$HEAD_REMOTE" = "$BASE_REMOTE" ]; then
+    BASE_VIEW=$HEAD_VIEW
+else
+    BASE_URL=$(remote_2_url "$BASE_REMOTE")
+    BASE_VIEW=$(gh repo view --json defaultBranchRef,name,owner "$BASE_URL")
+fi
 
 BASE_OWNER=$(echo "$BASE_VIEW" | jq -r '.owner.login')
 BASE_NAME=$(echo "$BASE_VIEW" | jq -r '.name')
@@ -470,7 +476,7 @@ if [ -z "$BASE_BRANCH" ]; then
 fi
 
 # Get the changes between $HEAD_REMOTE/$HEAD_BRANCH and $BASE_REMOTE/$BASE_BRANCH
-DIFF=$(git diff "remotes/$BASE_REMOTE/$BASE_BRANCH"..."remotes/$HEAD_REMOTE/$HEAD_BRANCH")
+DIFF=$(git diff "remotes/$BASE_REMOTE/$BASE_BRANCH...remotes/$HEAD_REMOTE/$HEAD_BRANCH")
 
 if [ -z "$DIFF" ]; then
     exit 0

--- a/aipr
+++ b/aipr
@@ -447,8 +447,16 @@ kill_spin
 
 HEAD_REMOTE=$(get_branch_remote "$HEAD_BRANCH")
 HEAD_URL=$(remote_2_url "$HEAD_REMOTE")
-HEAD_VIEW=$(gh repo view --json defaultBranchRef,name,owner "$HEAD_URL")
+if ! HEAD_VIEW=$(gh repo view --json defaultBranchRef,name,owner "$HEAD_URL"); then
+    echo "Error: Failed to get repo info for head remote URL: $HEAD_URL" >&2
+    exit 1
+fi
+
 HEAD_OWNER=$(echo "$HEAD_VIEW" | jq -r '.owner.login')
+if [ -z "$HEAD_OWNER" ] || [ "$HEAD_OWNER" = "null" ]; then
+    echo "Error: Could not determine owner from repo info for $HEAD_URL" >&2
+    exit 1
+fi
 
 if [ -z "$HEAD_OWNER" ]; then
     echo "The owner of $HEAD_URL is not found" >&2
@@ -463,7 +471,10 @@ if [ "$HEAD_REMOTE" = "$BASE_REMOTE" ]; then
     BASE_VIEW=$HEAD_VIEW
 else
     BASE_URL=$(remote_2_url "$BASE_REMOTE")
-    BASE_VIEW=$(gh repo view --json defaultBranchRef,name,owner "$BASE_URL")
+    if ! BASE_VIEW=$(gh repo view --json defaultBranchRef,name,owner "$BASE_URL"); then
+        echo "Error: Failed to get repo info for base remote URL: $BASE_URL" >&2
+        exit 1
+    fi
 fi
 
 BASE_OWNER=$(echo "$BASE_VIEW" | jq -r '.owner.login')


### PR DESCRIPTION
This pull request further refines the `aipr` script's ability to accurately handle Git remotes and create pull requests, especially within complex fork-based workflows, and improves the precision of the generated diffs.

The primary motivation for these changes is to enhance the script's robustness in identifying the correct owner of the head repository. Previously, `aipr` might incorrectly assume the `gh` authenticated user was the owner of the head branch, which is often not true in fork scenarios. By directly querying the head branch's remote URL using `gh repo view`, the script now reliably determines the `HEAD_OWNER`, ensuring the pull request commands and displayed information are always accurate. This prevents issues when creating PRs from a fork to its upstream.

Additionally, the `git diff` command syntax has been corrected. The previous quoting around individual branch names when using the `...` (three dots) merge-base comparison operator could lead to `git diff` misinterpreting the command. This fix ensures `git diff` correctly calculates the changes introduced by the head branch since its divergence from the base, providing a more accurate and expected diff for the pull request body.

## Changes:

*   **Accurate `HEAD_OWNER` Determination**: The script now uses `gh repo view` on the head branch's remote URL to correctly identify the owner of the head repository (e.g., `octocat` for `octocat/Spoon-Knife`), which is stored in the new `HEAD_OWNER` variable. This replaces the less precise `gh config get user` which only provided the authenticated user.
*   **Renamed `GH_USER` references**: All instances of `${GH_USER}` in `echo` statements and the `gh pr create -H` flag have been updated to `${HEAD_OWNER}` to reflect the accurate source of the pull request.
*   **Optimized Remote Information Fetching**:
    *   Comprehensive error handling has been added for all `gh repo view` calls to ensure graceful failure if repository information cannot be retrieved for either the head or base remotes.
    *   An optimization was implemented to avoid redundant `gh repo view` API calls for the base repository if the head and base remotes are identical, improving efficiency.
*   **Corrected `git diff` syntax for merge-base comparison**: The `git diff` command used to generate the changes for the PR has been adjusted from `git diff "remotes/$BASE_REMOTE/$BASE_BRANCH"..."remotes/$HEAD_REMOTE/$HEAD_BRANCH"` to `git diff "remotes/$BASE_REMOTE/$BASE_BRANCH...remotes/$HEAD_REMOTE/$HEAD_BRANCH"`. This ensures the `...` (three dots) operator is correctly interpreted by Git to calculate the true merge-base diff, representing only the changes introduced on the head branch relative to the base.

close #6
