### PR TITLE
Implement fallback for empty AI-generated PR body.

### DIFF
--- a/aipr
+++ b/aipr
@@ -245,6 +245,7 @@ generate_body() {
     DIFF="$1"
     TEMP_FILE="$2"
     EXTRA_SYSTEM="$3"
+    TEMPLATE_CONTENT="$4"
 
     SYSTEM=$(cat "$PROMPT_BODY")
     if [ -n "$EXTRA_SYSTEM" ]; then
@@ -264,8 +265,11 @@ EOF
     BODY=$(echo "$DIFF" | llm -s "$PROMPT")
     kill_spin
 
-    # TEMP_FILE=$(mktemp).md
-    echo "$BODY" >"$TEMP_FILE"
+    if [ -n "$BODY" ]; then
+        echo "$BODY" >"$TEMP_FILE"
+    else
+        echo "$TEMPLATE_CONTENT" >"$TEMP_FILE"
+    fi
     ${EDITOR:-vi} "$TEMP_FILE"
 }
 
@@ -291,7 +295,7 @@ EOF
     fi
 
     TEMP_FILE=$(mktemp).md
-    generate_body "$DIFF" "$TEMP_FILE" "$EXTRA_SYSTEM"
+    generate_body "$DIFF" "$TEMP_FILE" "$EXTRA_SYSTEM" "$TEMPLATE_CONTENT"
 
     read -p "Create PR with these details? [y/N] " confirm
     if [[ $confirm =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
### Improve PR Body Generation Fallback

close #7

### Why these changes?

This pull request enhances the `aipr` script's robustness when generating pull request descriptions. Previously, if the language model failed to generate a pull request body (e.g., returned an empty string), the temporary file opened in the editor would be empty. This could lead to a less intuitive user experience, as the user would be presented with a blank editor, requiring them to start from scratch.

This change introduces a fallback mechanism. Now, if the AI-generated body is empty, the editor will be pre-populated with a default template or placeholder content. This ensures that the user always has a starting point, even if the AI doesn't produce output, making the process smoother and more user-friendly.

### Changes in this PR

* Modified the `generate_body` function to accept an additional `TEMPLATE_CONTENT` argument.
* Updated the `create_pr` function to pass the `TEMPLATE_CONTENT` (which would typically be a default PR template or an empty string if no template is defined) to `generate_body`.
* Implemented a conditional check within `generate_body`: if the AI-generated `BODY` is empty, the `TEMP_FILE` opened in the editor will be populated with `TEMPLATE_CONTENT` instead of being empty.
* Removed a redundant commented-out line related to temporary file creation.
