### PR TITLE
Prevent empty PR body when AI generation fails.

### DIFF
--- a/aipr
+++ b/aipr
@@ -333,7 +333,7 @@ EOF
     )
 
     TEMP_FILE=$(mktemp).md
-    generate_body "$DIFF" "$TEMP_FILE" "$EXTRA_SYSTEM"
+    generate_body "$DIFF" "$TEMP_FILE" "$EXTRA_SYSTEM" "$OLD_BODY"
 
     read -p "Update PR #$ONGOING with these changes? [y/N] " confirm
     if [[ $confirm =~ ^[Yy]$ ]]; then

--- a/aipr
+++ b/aipr
@@ -245,6 +245,7 @@ generate_body() {
     DIFF="$1"
     TEMP_FILE="$2"
     EXTRA_SYSTEM="$3"
+    TEMPLATE_CONTENT="$4"
 
     SYSTEM=$(cat "$PROMPT_BODY")
     if [ -n "$EXTRA_SYSTEM" ]; then
@@ -264,8 +265,11 @@ EOF
     BODY=$(echo "$DIFF" | llm -s "$PROMPT")
     kill_spin
 
-    # TEMP_FILE=$(mktemp).md
-    echo "$BODY" >"$TEMP_FILE"
+    if [ -n "$BODY" ]; then
+        echo "$BODY" >"$TEMP_FILE"
+    else
+        echo "$TEMPLATE_CONTENT" >"$TEMP_FILE"
+    fi
     ${EDITOR:-vi} "$TEMP_FILE"
 }
 
@@ -291,7 +295,7 @@ EOF
     fi
 
     TEMP_FILE=$(mktemp).md
-    generate_body "$DIFF" "$TEMP_FILE" "$EXTRA_SYSTEM"
+    generate_body "$DIFF" "$TEMP_FILE" "$EXTRA_SYSTEM" "$TEMPLATE_CONTENT"
 
     read -p "Create PR with these details? [y/N] " confirm
     if [[ $confirm =~ ^[Yy]$ ]]; then


### PR DESCRIPTION
This pull request enhances the robustness of the `aipr` script by introducing a fallback mechanism for generating pull request bodies. Previously, if the AI model failed to generate a body (e.g., returned an empty string), the temporary file opened for editing would be empty. This change ensures that a default or previous content is provided as a starting point, improving the user experience and preventing loss of information, especially when updating existing pull requests.

close #7

### Changes

* **Modified `generate_body` function signature:** Added a new parameter `TEMPLATE_CONTENT` to allow passing fallback content.
* **Implemented fallback logic in `generate_body`:** If the `llm` command returns an empty string for the PR body, the `TEMP_FILE` will now be populated with the provided `TEMPLATE_CONTENT` instead.
* **Updated calls to `generate_body`:**
  * In the `create_pr` function, `generate_body` now receives `"$TEMPLATE_CONTENT"` (which will likely be empty for new PRs, but sets up the parameter).
  * In the `update_pr` function, `generate_body` now passes the `"$OLD_BODY"` of the existing PR as the `TEMPLATE_CONTENT`. This means if the AI fails to generate a new body during an update, the temporary editor file will be pre-filled with the PR's current description, preventing data loss and providing a useful starting point.
